### PR TITLE
Widget Text Autosizing

### DIFF
--- a/app/src/main/java/net/diffengine/romandigitalclock/TimeDisplayWidget.java
+++ b/app/src/main/java/net/diffengine/romandigitalclock/TimeDisplayWidget.java
@@ -310,13 +310,16 @@ public class TimeDisplayWidget extends AppWidgetProvider {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
         boolean ampm = sp.getBoolean("switch_format" + appWidgetId, false);
         String maxlengthText = context.getString((ampm == MainActivity.left) ? R.string.civ_fill : R.string.mil_fill);
-        int widgetWidth = 0;
-        int widgetHeight = 0;
+        int widgetWidth;
+        int widgetHeight;
 
         // Set up Rect containing widget rectangle into which to fit text
         // 1) Get widget width and height in DIP
-        int widgetWidthDp = bundle.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH);
-        int widgetHeightDp = bundle.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT);
+        boolean isPortrait = (context.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT);
+        String widthOption = (isPortrait) ? AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH : AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH;
+        String heightOption = (isPortrait) ? AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT : AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT;
+        int widgetWidthDp = bundle.getInt(widthOption);
+        int widgetHeightDp = bundle.getInt(heightOption);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             // 2) Assign the DIP width and height directly to the variables used in setting up Rect
             widgetWidth = widgetWidthDp;
@@ -332,9 +335,7 @@ public class TimeDisplayWidget extends AppWidgetProvider {
         }
         Rect maxRect = new Rect(0, 0, widgetWidth-1, widgetHeight-1);
 
-        int maxTextSize = findMaxTextSize(context, maxRect, maxlengthText);
-
-        return maxTextSize;
+        return findMaxTextSize(context, maxRect, maxlengthText);
     }
 
     static private void setTimeTextSize(Context context, RemoteViews views, int appWidgetId, Bundle widgetOptions) {

--- a/app/src/main/java/net/diffengine/romandigitalclock/TimeDisplayWidget.java
+++ b/app/src/main/java/net/diffengine/romandigitalclock/TimeDisplayWidget.java
@@ -30,6 +30,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.Typeface;
@@ -289,7 +290,13 @@ public class TimeDisplayWidget extends AppWidgetProvider {
 
             paint.setTextSize(textSize);
             paint.getTextBounds(refText, 0, refText.length(), rect);
-            if (rect.width() >= maxRect.width()) {
+
+            int orientation = context.getResources().getConfiguration().orientation;
+            if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                rect.bottom += paint.getFontSpacing();
+            }
+
+            if ((rect.width() >= maxRect.width()) || (rect.height() >= maxRect.height())) {
                 hiSize = midSize;
             } else {
                 loSize = midSize;

--- a/app/src/main/java/net/diffengine/romandigitalclock/TimeDisplayWidget.java
+++ b/app/src/main/java/net/diffengine/romandigitalclock/TimeDisplayWidget.java
@@ -123,8 +123,7 @@ public class TimeDisplayWidget extends AppWidgetProvider {
             }
 
             Bundle widgetOptions = AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId);
-            int textsize = calcTimeDisplayTextSize(widgetOptions);
-            views.setTextViewTextSize(R.id.appwidget_text, TypedValue.COMPLEX_UNIT_SP, textsize);
+            setTimeTextSize(views, widgetOptions);
 //        }
 
         Intent intent;
@@ -257,18 +256,21 @@ public class TimeDisplayWidget extends AppWidgetProvider {
         return ((minwidth < 260) ? 28 : 34);
     }
 
+    static private void setTimeTextSize(RemoteViews views, Bundle widgetOptions) {
+        int textsize = calcTimeDisplayTextSize(widgetOptions);
+        views.setTextViewTextSize(R.id.appwidget_text, TypedValue.COMPLEX_UNIT_SP, textsize);
+    }
+
     @Override
     public void onAppWidgetOptionsChanged(Context context, AppWidgetManager appWidgetManager,
                                           int appWidgetId, Bundle newOptions) {
-        int textsize = calcTimeDisplayTextSize(newOptions);
 
-        // This call to updateTimeDisplay, which calls appWidgetManager.updateAppWidget, should likely be replaced with
-        // "RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.time_display_widget);"
-        // because the current arrangement causes redundant calls to appWidgetManager.updateAppWidget.
-        // *** But needs to be thoroughly tested first. ***
+        // This call needs to be here rather than just instantiating a new RemoteViews
+        // object so the display will be updated for each of the multiple calls to
+        // onAppWidgetOptionsChanged that may occur while the user is resizing a widget
         RemoteViews views = updateTimeDisplay(context, SETTINGS_KICK, appWidgetId);
 
-        views.setTextViewTextSize(R.id.appwidget_text, TypedValue.COMPLEX_UNIT_SP, textsize);
+        setTimeTextSize(views, newOptions);
         appWidgetManager.updateAppWidget(appWidgetId, views);
     }
 }

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -24,11 +24,9 @@
 <resources>
     <style name="Widget.RomanDigitalClock.AppWidget.Container" parent="android:Widget">
         <item name="android:id">@android:id/background</item>
-        <item name="android:padding">?attr/appWidgetPadding</item>
     </style>
 
     <style name="Widget.RomanDigitalClock.AppWidget.InnerView" parent="android:Widget">
-        <item name="android:padding">?attr/appWidgetPadding</item>
         <item name="android:background">@drawable/app_widget_inner_view_background</item>
         <item name="android:textColor">?android:attr/textColorPrimary</item>
     </style>

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -24,13 +24,11 @@
 <resources>
     <style name="Widget.RomanDigitalClock.AppWidget.Container" parent="android:Widget">
         <item name="android:id">@android:id/background</item>
-        <item name="android:padding">?attr/appWidgetPadding</item>
         <item name="android:background">@drawable/app_widget_background</item>
         <item name="android:clipToOutline">true</item>
     </style>
 
     <style name="Widget.RomanDigitalClock.AppWidget.InnerView" parent="android:Widget">
-        <item name="android:padding">?attr/appWidgetPadding</item>
         <item name="android:background">@drawable/app_widget_inner_view_background</item>
         <item name="android:textColor">?android:attr/textColorPrimary</item>
         <item name="android:clipToOutline">true</item>

--- a/app/src/main/res/xml/time_display_widget_info.xml
+++ b/app/src/main/res/xml/time_display_widget_info.xml
@@ -38,7 +38,7 @@
     android:configure="net.diffengine.romandigitalclock.TimeDisplayWidgetConfigActivity"
     android:widgetFeatures="reconfigurable"
     android:minWidth="180dp"
-    android:minResizeWidth="180dp"
+    android:minResizeWidth="115dp"
     android:minHeight="40dp"
     android:minResizeHeight="40dp"
     android:updatePeriodMillis="86400000"


### PR DESCRIPTION
The changes added in the five commits included in this merge enable the app widget time display text to autosize itself to the largest size that will fit within the widget width, where the app widget is scalable to a width as small as two cells.

Known Issue: Unless the particular device UI/launcher rendering the device's home screen on which the widget is installed causes onAppWidgetOptionsChanged to be called when the device is rotated, text of a widget rotated between portrait and landscape will not be autosized until the next widget update. This may be up to a minute after the rotation. This issue is of no concern for devices the do not support home screen rotation or that are set not to rotate the home screen.